### PR TITLE
Fix #30 Do not pack the plugin into a zip file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,11 +24,9 @@
   </path>
   
   <target name="assemble" depends="classes, declare-mps-tasks">
-    <mkdir dir="${build.layout}" />
-    <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.zip" />
-    <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen" />
-    <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/META-INF" />
-    <echoxml file="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/META-INF/plugin.xml">
+    <mkdir dir="${build.layout}/com.dslfoundry.plaintextgen" />
+    <mkdir dir="${build.layout}/com.dslfoundry.plaintextgen/META-INF" />
+    <echoxml file="${build.layout}/com.dslfoundry.plaintextgen/META-INF/plugin.xml">
       <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
         <id>com.dslfoundry.plaintextgen</id>
         <name>com.dslfoundry.plaintextgen</name>
@@ -44,8 +42,8 @@
         </extensions>
       </idea-plugin>
     </echoxml>
-    <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages" />
-    <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen" />
+    <mkdir dir="${build.layout}/com.dslfoundry.plaintextgen/languages" />
+    <mkdir dir="${build.layout}/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen" />
     <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.jar" />
     <mkdir dir="${build.tmp}/default/com.dslfoundry.plaintextgen.jar/META-INF" />
     <echoxml file="${build.tmp}/default/com.dslfoundry.plaintextgen.jar/META-INF/module.xml">
@@ -73,7 +71,7 @@
         <sources jar="com.dslfoundry.plaintextgen-src.jar" descriptor="com.dslfoundry.plaintextgen.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/com.dslfoundry.plaintextgen" />
       <fileset dir="${basedir}/languages/com.dslfoundry.plaintextgen" includes="icons/**, resources/**" />
       <fileset dir="${basedir}/languages/com.dslfoundry.plaintextgen/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
@@ -101,7 +99,7 @@
         <sources jar="com.dslfoundry.plaintextgen-src.jar" descriptor="com.dslfoundry.plaintextgen.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen-generator.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen-generator.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/com.dslfoundry.plaintextgen#5198309202559528987" />
       <fileset dir="${build.tmp}/default/com.dslfoundry.plaintextgen-generator.jar" />
     </jar>
@@ -111,7 +109,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-com.dslfoundry.plaintextgen-models">
       <fileset dir="${basedir}/languages/com.dslfoundry.plaintextgen/models" includes="**/*.mps, **/*.metadata, **/*.history, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen-src.jar" duplicate="preserve">
       <fileset dir="${basedir}/languages/com.dslfoundry.plaintextgen/generator/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -139,7 +137,7 @@
         <sources jar="com.dslfoundry.plaintextgen.build-src.jar" descriptor="com.dslfoundry.plaintextgen.build.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.build.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.build.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/com.dslfoundry.plaintextgen.build" />
       <fileset dir="${basedir}/solutions/com.dslfoundry.plaintextgen.build" includes="icons/**, resources/**" />
       <fileset dir="${basedir}/solutions/com.dslfoundry.plaintextgen.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
@@ -148,7 +146,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-com.dslfoundry.plaintextgen.build-models">
       <fileset dir="${basedir}/solutions/com.dslfoundry.plaintextgen.build/models" includes="**/*.mps, **/*.metadata, **/*.history, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/com.dslfoundry.plaintextgen.zip/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.build-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/com.dslfoundry.plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.build-src.jar" duplicate="preserve">
       <fileset dir="${basedir}/solutions/com.dslfoundry.plaintextgen.build/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -158,9 +156,6 @@
       <zipfileset file="${basedir}/solutions/com.dslfoundry.plaintextgen.build/com.dslfoundry.plaintextgen.build.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-com.dslfoundry.plaintextgen.build-models" prefix="module/models" />
     </jar>
-    <zip destfile="${build.layout}/com.dslfoundry.plaintextgen.zip">
-      <fileset dir="${build.tmp}/default/com.dslfoundry.plaintextgen.zip" />
-    </zip>
     <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
   </target>
   

--- a/solutions/com.dslfoundry.plaintextgen.build/models/com/dslfoundry/plaintextgen/build.mps
+++ b/solutions/com.dslfoundry.plaintextgen.build/models/com/dslfoundry/plaintextgen/build.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="-1" />
-    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="5" />
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="-1" />
     <use id="9ded098b-ad6a-4657-bfd9-48636cfe8bc3" name="jetbrains.mps.lang.traceable" version="-1" />
     <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="-1" />
   </languages>
@@ -41,10 +41,6 @@
         <child id="8618885170173601778" name="tail" index="2Ry0An" />
       </concept>
       <concept id="6647099934206700647" name="jetbrains.mps.build.structure.BuildJavaPlugin" flags="ng" index="10PD9b" />
-      <concept id="7389400916848050071" name="jetbrains.mps.build.structure.BuildLayout_Zip" flags="ng" index="3981dG" />
-      <concept id="7389400916848050060" name="jetbrains.mps.build.structure.BuildLayout_NamedContainer" flags="ng" index="3981dR">
-        <child id="4380385936562148502" name="containerName" index="Nbhlr" />
-      </concept>
       <concept id="7389400916848136194" name="jetbrains.mps.build.structure.BuildFolderMacro" flags="ng" index="398rNT" />
       <concept id="7389400916848153117" name="jetbrains.mps.build.structure.BuildSourceMacroRelativePath" flags="ng" index="398BVA">
         <reference id="7389400916848153130" name="macro" index="398BVh" />
@@ -149,15 +145,8 @@
       </node>
     </node>
     <node concept="1l3spV" id="2NTGYE$JTHf" role="1l3spN">
-      <node concept="3981dG" id="2NTGYE$JTHg" role="39821P">
-        <node concept="3_J27D" id="2NTGYE$JTHh" role="Nbhlr">
-          <node concept="3Mxwew" id="2NTGYE$JTHi" role="3MwsjC">
-            <property role="3MwjfP" value="com.dslfoundry.plaintextgen.zip" />
-          </node>
-        </node>
-        <node concept="m$_wl" id="2NTGYE$JTHj" role="39821P">
-          <ref role="m_rDy" node="2NTGYE$JTH6" resolve="com.dslfoundry.plaintextgen" />
-        </node>
+      <node concept="m$_wl" id="2NTGYE$JTHj" role="39821P">
+        <ref role="m_rDy" node="2NTGYE$JTH6" resolve="com.dslfoundry.plaintextgen" />
       </node>
     </node>
     <node concept="m$_wf" id="2NTGYE$JTH6" role="3989C9">


### PR DESCRIPTION
Deliver the plugin artifacts as an extracted folder instead
of a zip file, so it is usable for both command line builds
and builds inside MPS.

Signed-off-by: Bart vdr. Meulen <bartvdrmeulen@gmail.com>